### PR TITLE
fix: video playback state detection 

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "packageManager": "pnpm@8.15.0",
   "engines": {
-    "node": "20.x",
+    "node": "22.x",
     "pnpm": "8.15.0"
   }
 }

--- a/src/content/components/task/TaskCard.tsx
+++ b/src/content/components/task/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { differenceInDays, differenceInHours, isPast, format } from 'date-fns'
 import { ko } from 'date-fns/locale'
-import { Video, FileText, CheckCircle, AlertTriangle, Clock, XCircle } from 'lucide-react'
+import { Video, FileText, HelpCircle, CheckCircle, AlertTriangle, Clock, XCircle } from 'lucide-react'
 
 import type { Activity } from '@/types'
 import { cn } from '@/utils/cn'
@@ -50,7 +50,8 @@ export function TaskCard({ task }: Props) {
 
   const getExactDeadline = () => format(endAtDate, 'M월 d일(E) HH:mm', { locale: ko })
 
-  const taskLink = `${window.location.origin}/mod/${task.type === 'assignment' ? 'assign' : 'vod'}/view.php?id=${task.id}`
+  const modulePath = task.type === 'assignment' ? 'assign' : task.type === 'video' ? 'vod' : 'quiz'
+  const taskLink = `${window.location.origin}/mod/${modulePath}/view.php?id=${task.id}`
 
   return (
     <a href={taskLink} rel="noopener noreferrer" className="block">
@@ -67,7 +68,7 @@ export function TaskCard({ task }: Props) {
         <div className="p-12px">
           <div className="flex items-start">
             <span className="mr-8px mt-2px flex-shrink-0 text-gray-500">
-              {task.type === 'video' ? <Video size={16} /> : <FileText size={16} />}
+              {task.type === 'video' ? <Video size={16} /> : task.type === 'assignment' ? <FileText size={16} /> : <HelpCircle size={16} />}
             </span>
             <div className="flex flex-1 flex-col">
               <h3 className="mb-2px flex-1 break-keep text-14px font-semibold text-gray-700">{task.title}</h3>

--- a/src/services/parser/constants/selectors.ts
+++ b/src/services/parser/constants/selectors.ts
@@ -16,6 +16,12 @@ export const domSelectorsSchema = z.object({
       title: z.string(),
       period: z.string(),
     }),
+    quiz: z.object({
+      container: z.string(),
+      link: z.string(),
+      title: z.string(),
+      period: z.string(),
+    }),
     video: z.object({
       container: z.string(),
       link: z.string(),
@@ -57,8 +63,14 @@ export const DOM_SELECTORS = domSelectorsSchema.parse({
       title: '.instancename',
       period: '.displayoptions',
     },
+    quiz: {
+      container: '.modtype_quiz .activityinstance',
+      link: 'a',
+      title: '.instancename',
+      period: '.displayoptions',
+    },
     video: {
-      container: '.modtype_vod .activityinstance',
+      container: '.modtype_vod .activityinstance, .modtype_ubionvod .activityinstance, .modtype_kollus .activityinstance',
       link: 'a',
       title: '.instancename',
       period: '.displayoptions .text-ubstrap',

--- a/src/services/parser/index.ts
+++ b/src/services/parser/index.ts
@@ -4,7 +4,7 @@ import { URL_PATTERNS } from './constants/urls'
 import { fetchAndParse } from './utils/dom'
 import { UNIVERSITY_LINK_LIST, UNIVERSITY_NAME_MAP } from '@/constants/univ'
 import type { University, UniversityLink } from '@/constants/univ'
-import type { Activity, Assignment, Course, Video } from '@/types'
+import type { Activity, Assignment, Course, Video, Quiz } from '@/types'
 import { getLinkId, mapElement, getAttr, getText } from '@/utils'
 
 import type * as cheerio from 'cheerio'
@@ -85,6 +85,32 @@ export function parseVideos(
   }).flat()
 }
 
+export function parseQuizzes(
+  $: cheerio.CheerioAPI,
+  courseId: string,
+): Array<Omit<Quiz, 'courseTitle' | 'hasSubmitted'>> {
+  const { sections, quiz } = DOM_SELECTORS.activities
+
+  const parseQuiz = ($el: cheerio.Cheerio<AnyNode>, _sectionTitle?: string) => {
+    const id = getLinkId(getAttr($el.find(quiz.link), 'href'))
+    const title = getText($el.find(quiz.title).clone().children().remove().end())
+    const [startAt, endAt] = getText($el.find(quiz.period).clone().children().remove().end())
+      .split(' ~ ')
+      .map(t => t.trim())
+    return { type: 'quiz' as const, id, courseId, title, startAt, endAt }
+  }
+
+  const sectionOne = mapElement($(`${sections.first} ${quiz.container}`), (_, el) => parseQuiz($(el)))
+
+  const sectionTwo = mapElement($(sections.all), (_, content) => {
+    const $content = $(content)
+    const sectionTitle = getText($content.find(sections.title))
+    return mapElement($content.find(quiz.container), (_, el) => parseQuiz($(el), sectionTitle))
+  }).flat()
+
+  return [...sectionOne, ...sectionTwo]
+}
+
 export function parseAssignmentSubmitted(
   $: cheerio.CheerioAPI,
 ): Array<Pick<Assignment, 'id' | 'title' | 'hasSubmitted' | 'endAt'>> {
@@ -113,13 +139,13 @@ export function parseVideoSubmitted(
   return mapElement($(container), (_, el) => {
     const $el = $(el)
     const $sectionTitle = $el.find(sectionTitle)
-    const originalTitle = $sectionTitle.attr('title')
+    const originalTitle = $sectionTitle.attr('title') || $sectionTitle.text()
 
     if (originalTitle != null && originalTitle !== '') {
       currentSectionTitle = originalTitle
     }
 
-    const videoTitle = getText($el.find(title))
+    const videoTitle = getText($el.find(title).clone().children().remove().end())
     const $std = $el.find(requiredTime)
     const required = getText($std) // mm:ss
     const study = getText($std.next().clone().children().remove().end()) // mm:ss
@@ -156,10 +182,23 @@ export async function getActivities(
     return findAssignment ? [...acc, { ...cur, ...findAssignment, courseTitle }] : acc
   }, [])
 
+  const normalize = (text: string) => text.replace(/\s+/g, ' ').trim()
+
   const videos = parseVideos($, courseId).reduce<Video[]>((acc, cur) => {
-    const findVideo = videoSubmittedArray.find(v => v.sectionTitle === cur.sectionTitle && v.title === cur.title)
+    // 우선 섹션+제목 완전 일치 시도
+    let findVideo = videoSubmittedArray.find(
+      v => normalize(v.sectionTitle) === normalize(cur.sectionTitle) && normalize(v.title) === normalize(cur.title),
+    )
+
+    // 실패 시, 섹션명을 제외하고 제목만으로 매칭(fallback)
+    if (!findVideo) {
+      findVideo = videoSubmittedArray.find(v => normalize(v.title) === normalize(cur.title))
+    }
+
     return findVideo ? [...acc, { ...cur, ...findVideo, courseTitle }] : acc
   }, [])
 
-  return [...assignments, ...videos]
+  const quizzes = parseQuizzes($, courseId).map(q => ({ ...q, courseTitle, hasSubmitted: false }))
+
+  return [...assignments, ...videos, ...quizzes]
 }

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -21,7 +21,11 @@ export interface Video extends BaseActivity {
   sectionTitle: string
 }
 
-export type Activity = Assignment | Video
+export interface Quiz extends BaseActivity {
+  type: 'quiz'
+}
+
+export type Activity = Assignment | Video | Quiz
 
 export type Contents = {
   courseList: Course[]


### PR DESCRIPTION
## Description

가천대학교 사이버캠퍼스 업데이트로 인한 UI 변경으로 동영상 시청 여부 및 목록이 불러와지지 않는 오류를 다음과 같이 수정했습니다.
 * 영상 매칭 조건 완화: 섹션과 제목이 일치하는지를 우선 판단하고, 아닐 경우 제목만 매칭합니다.
 * 섹션명 수정: `.sectiontitle`에 title이 없으면 텍스트를 사용합니다.
 * 제목 정규화 수정: 공백 정규화 및 접근성 스팬 제거 후 비교하도록 합니다.
 * 선택자 추가: 유비온 공통 포맷에 따라 `.modtype_vod`, `.modtype_ubionvod`, `modtype_kollus`를 모두 추가합니다.

## Check List

- [ ] [CONTRIBUTING.md](https://github.com/kangju2000/gachon-tools/blob/main/CONTRIBUTING.md)를 읽었으며, 내용을 준수했습니다.
